### PR TITLE
change postgresql deployment to statefulset

### DIFF
--- a/charts/concrnt/templates/deployment.yaml
+++ b/charts/concrnt/templates/deployment.yaml
@@ -154,43 +154,6 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: concurrent-db
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      name: concurrent-db
-  template:
-    metadata:
-      labels:
-        name: concurrent-db
-    spec:
-      containers:
-      - name: posgresql
-        image: postgres
-        ports:
-          - containerPort: 5432
-        imagePullPolicy: IfNotPresent
-        env:
-          - name: POSTGRES_USER
-            value: postgres
-          - name: POSTGRES_PASSWORD
-            value: postgres
-          - name: POSTGRES_DB
-            value: concrnt
-        volumeMounts:
-          - name: postgres-varlib
-            mountPath: /var/lib/postgresql
-      volumes:
-        - name: postgres-varlib
-          persistentVolumeClaim:
-            claimName: postgres-varlib
-
----
-
-apiVersion: apps/v1
-kind: Deployment
-metadata:
   name: concurrent-redis
 spec:
   replicas: 1

--- a/charts/concrnt/templates/statefulset.yaml
+++ b/charts/concrnt/templates/statefulset.yaml
@@ -1,0 +1,35 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: concurrent-db
+spec:
+  replicas: 1
+  serviceName: concurrent-db
+  selector:
+    matchLabels:
+      name: concurrent-db
+  template:
+    metadata:
+      labels:
+        name: concurrent-db
+    spec:
+      containers:
+        - name: posgresql
+          image: postgres
+          ports:
+            - containerPort: 5432
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: POSTGRES_USER
+              value: postgres
+            - name: POSTGRES_PASSWORD
+              value: postgres
+            - name: POSTGRES_DB
+              value: concrnt
+          volumeMounts:
+            - name: postgres-varlib
+              mountPath: /var/lib/postgresql
+      volumes:
+        - name: postgres-varlib
+          persistentVolumeClaim:
+            claimName: postgres-varlib


### PR DESCRIPTION
Replicas: 1 の場合でも、Deploymentの場合はPodがTerminating状態になったと同時に新たなPodをCreateするので2プロセス同時に `/var/lib/postgresql` を掴む可能性があり、多少DB破損のリスクがあります。

Statefulsetは同時に1プロセスのみ立ち上がることが保証されているのでより安心です。
