### PR TITLE
Use fully qualified image names instead of short names (specify docker.io/)

### DIFF
--- a/charts/concrnt/templates/deployment.yaml
+++ b/charts/concrnt/templates/deployment.yaml
@@ -206,13 +206,13 @@ spec:
     spec:
       containers:
       - name: memcached
-        image: memcached:1.6-bookworm
+        image: docker.io/memcached:1.6-bookworm
         ports:
           - name: memcached
             containerPort: 11211
 {{- if .Values.memcached.createExporter }}
       - name: memcached-exporter
-        image: prom/memcached-exporter:v0.6.0
+        image: docker.io/prom/memcached-exporter:v0.6.0
         ports:
           - name: memcached-expr
             containerPort: 9150

--- a/charts/concrnt/templates/statefulset.yaml
+++ b/charts/concrnt/templates/statefulset.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: posgresql
-          image: postgres:16-bookworm
+          image: docker.io/postgres:16-bookworm
           ports:
             - name: postgres
               containerPort: 5432
@@ -115,7 +115,7 @@ spec:
     spec:
       containers:
       - name: redis
-        image: redis:7-bookworm
+        image: docker.io/redis:7-bookworm
         ports:
           - name: redis
             containerPort: 6379
@@ -124,7 +124,7 @@ spec:
             mountPath: /data
 {{- if .Values.redis.createExporter }}
       - name: redis-exporter
-        image: oliver006/redis_exporter:v1.6.0-alpine
+        image: docker.io/oliver006/redis_exporter:v1.6.0-alpine
         ports:
           - name: redis-exporter
             containerPort: 9121

--- a/charts/concrnt/values.yaml
+++ b/charts/concrnt/values.yaml
@@ -128,6 +128,6 @@ memcached:
 meilisearch:
   enabled: false
   useSecret: false
-  image: getmeili/meilisearch:prototype-japanese-13
+  image: docker.io/getmeili/meilisearch:prototype-japanese-13
   storage: "1Gi"
 


### PR DESCRIPTION
ref. github.com/cri-o/cri-o/pull/9401

cri-o v.1.34.0 からデフォルトで `docker.io` を省略する形のイメージ指定ができなくなったため、省略されているイメージタグ名に `docker.io/` を追加しました。 